### PR TITLE
ignore matches without date (calendar adding)

### DIFF
--- a/pkg/calendar/calendar.go
+++ b/pkg/calendar/calendar.go
@@ -32,6 +32,11 @@ func ConvertGesamtspielplanToGroupAndTeamCalendars(gsp sport.Gesamtspielplan) (*
 	gspDesc := gsp.GetDescription()
 
 	for _, m := range gsp.Matches {
+		// skip adding match if no date is not available
+		if m.Date.IsZero() {
+			continue
+		}
+
 		// create event
 		e := createEventFromMatch(m, gsp, gspDesc)
 


### PR DESCRIPTION
Issue: Matches without a date will be set to 1.1.1 (year 1) which will not be helpful.
Therefore we will skip these matches from adding to the calendar.

closes #17